### PR TITLE
Actually change variable name to avoid multiple definitions

### DIFF
--- a/modules/FvwmTaskBar/FvwmTaskBar.c
+++ b/modules/FvwmTaskBar/FvwmTaskBar.c
@@ -91,7 +91,7 @@ XFontStruct *ButtonFont, *SelButtonFont;
 #ifdef I18N
 XFontSet ButtonFontset, SelButtonFontset;
 #endif
-int fontheight;
+int font_height;
 static Atom wm_del_win;
 Atom MwmAtom = None;
 
@@ -1161,10 +1161,10 @@ void StartMeUp()
    }
 #endif
    
-   fontheight = SelButtonFont->ascent + SelButtonFont->descent;
+   font_height = SelButtonFont->ascent + SelButtonFont->descent;
 
    NRows = 1;
-   RowHeight = fontheight + 8;
+   RowHeight = font_height + 8;
 
    win_border = 4; /* default border width */
    win_height = RowHeight;


### PR DESCRIPTION
This should fix issue https://github.com/mintsuki/fvwm95/issues/5, I was able to compile FvwmTaskbar on Arch with GCC 12.2 by changing fontheight to font_height in FvwmTaskbar.c, as the same variable is also defined in Goodies.c.

I apologize for my last pull request, I'm new to working to version control and wasn't aware making a pull request will pull in all commits in the head repository.